### PR TITLE
setLNA() had incorrect type on LnaZin

### DIFF
--- a/bareRFM69.h
+++ b/bareRFM69.h
@@ -409,7 +409,7 @@ class bareRFM69 {
         // Receiver Registers
         //#####################################################################
 
-        void setLNA(bool LnaZin, uint8_t LnaGainSelect){
+        void setLNA(uint8_t LnaZin, uint8_t LnaGainSelect){
             this->writeRegister(RFM69_LNA, LnaZin+LnaGainSelect);};
         /*  
             LnaZin:


### PR DESCRIPTION
Its a minor change but LnaZin was specified as bool. It needs to be 8 bit in order to have the correct bit field values for setting 200 ohm, which is recommended value in the datasheet and what is used in the example sketch. Because the type was wrong it would set the value to 50 ohm even when specifying 200.  As bool it can't set bit 7. As a bool, the example sketch sets RegLna to 0x09 which is 50 ohm and max gain even though 200 ohm and automatic gain was specified.  As a uint8_t it correctly sets RegLna to 0x88.