### PR TITLE
Changed second call to pinMode() to digitalWrite()

### DIFF
--- a/bareRFM69.h
+++ b/bareRFM69.h
@@ -52,7 +52,7 @@ class bareRFM69 {
         bareRFM69(uint8_t cs_pin){
             this->cs_pin = cs_pin;
             pinMode(this->cs_pin, OUTPUT);
-            pinMode(this->cs_pin, HIGH);
+            digitalWrite(this->cs_pin, HIGH);
 
             // Max 10 MHz clock, MSB first, CPOL= 0 and CPHA = 0
             // according to the datasheet.


### PR DESCRIPTION
Minor correction. The bareRFM69() constructor sets the cs_pin to output via pinMode() but accidentally calls pinMode() again when it looks like the intention was to initialize the chip select output to "high" level.  Looks like a copy and paste typo. That pin must default to a high level output so it worked, or was set to correct levels soon enough to not matter.