### PR TITLE
Change setFrequency signature to accomodate 868 MHz.

### DIFF
--- a/plainRFM69.cpp
+++ b/plainRFM69.cpp
@@ -95,9 +95,10 @@ void plainRFM69::setPacketLength(uint8_t length){
 
 }
 
-void plainRFM69::setFrequency(uint32_t freq){
+void plainRFM69::setFrequency(uint64_t freq){
     // 61 should be 61.03515625 for precision.
-    this->setFrf(freq/61);
+    const uint64_t divider = 61;
+    this->setFrf(freq / divider);
 }
 
 

--- a/plainRFM69.h
+++ b/plainRFM69.h
@@ -189,7 +189,7 @@ class plainRFM69 : public bareRFM69{
 
         */
 
-        void setFrequency(uint32_t freq);
+        void setFrequency(uint64_t freq);
         /*
             Sets the frequency to approximately Freq.
             Uses 61 as Fstep instead of 61.03515625 which it actually is.


### PR DESCRIPTION
This should fix #12 .

868 MHz was outside a 32 bit integer. Changing the signature to 64 bits should accomodate the higher frequencies and not break backwards comptability.